### PR TITLE
Update README to v1.5.1 and publish the agent skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Local Memory - Binary Distribution
 
-**Version 1.4.1** - Ready-to-run binaries for macOS, Linux, and Windows.
+**Version 1.5.1** - Ready-to-run binaries for macOS, Linux, and Windows.
 
 Local Memory is an AI-powered persistent memory system with vector search, semantic analysis, and intelligent categorization through the Model Context Protocol (MCP). It works with Claude Code, Claude Desktop, Gemini, Codex, Cursor, and other MCP-compatible tools.
 
@@ -10,8 +10,8 @@ Local Memory is an AI-powered persistent memory system with vector search, seman
 |----------|----------|
 | **macOS (Apple Silicon)** | [local-memory-macos-arm](https://github.com/danieleugenewilliams/local-memory-releases/releases/latest/download/local-memory-macos-arm) |
 | **macOS (Intel)** | [local-memory-macos-intel](https://github.com/danieleugenewilliams/local-memory-releases/releases/latest/download/local-memory-macos-intel) |
-| **macOS (Universal)** | [local-memory-universal.zip](https://github.com/danieleugenewilliams/local-memory-releases/releases/latest/download/local-memory-universal.zip) |
 | **Linux (x64)** | [local-memory-linux](https://github.com/danieleugenewilliams/local-memory-releases/releases/latest/download/local-memory-linux) |
+| **Linux (ARM64)** | [local-memory-linux-arm](https://github.com/danieleugenewilliams/local-memory-releases/releases/latest/download/local-memory-linux-arm) |
 | **Windows (x64)** | [local-memory-windows.exe](https://github.com/danieleugenewilliams/local-memory-releases/releases/latest/download/local-memory-windows.exe) |
 
 ## Quick Start
@@ -21,13 +21,13 @@ Local Memory is an AI-powered persistent memory system with vector search, seman
 chmod +x ./local-memory-*
 
 # 2. Activate license
-./local-memory license activate LM-XXXX-XXXX-XXXX-XXXX-XXXX
+./local-memory license activate LM-XXXX-XXXX-XXXX-XXXX-XXXX --accept_terms
 
 # 3. Start the service
 ./local-memory start
 
 # 4. Store and search memories
-./local-memory remember "Important project notes"
+./local-memory observe "Important project notes"
 ./local-memory search "project notes"
 ```
 
@@ -59,7 +59,22 @@ Use the full path to your downloaded binary.
 
 **Linux**: Ensure executable permissions with `chmod +x ./local-memory-linux`.
 
-## What's New in v1.4.1
+## Agent Skill
+
+A cross-vendor [Agent Skill](https://agentskills.io) that teaches AI agents to use Local Memory well — capture insights, recall prior context, and grow durable expertise across sessions — lives in [`integrations/local-memory-skill/`](integrations/local-memory-skill/). It works with Claude Code/Desktop, OpenAI Codex, Gemini CLI, Cursor, GitHub Copilot/VS Code, and Windsurf. See its [README](integrations/local-memory-skill/README.md) to install as a Claude Code plugin or copy into any agent's skills directory.
+
+## What's New
+
+### v1.5.1 — Questions Listing Tool
+
+- **`questions` tool** (MCP, REST, CLI) — list pending questions, contradictions, and epistemic gaps with filters (`status`, `question_type`, `priority_min`, `domain`) and four response formats. Closes the triage gap where pending items were only reachable via raw SQLite queries.
+
+### v1.5.0 — Knowledge Engineering Maturity
+
+- Completes the shift from a CRUD store to a knowledge-engineering system: knowledge-level vocabulary (Observation → Learning → Pattern → Schema) surfaces in every response, a safe and idempotent `observe → reflect → evolve` pipeline, consistent enrichment across MCP/REST/CLI, and six security fixes.
+- **Breaking changes** when upgrading from 1.4.x: the `store_memory` (MCP) and `remember` (CLI) commands were removed — use `observe` instead; the response shapes of `observe`, `question`, `reflect`, `evolve`, and `validate` changed; and `validate` auto-fix is now gated behind an explicit confirmation. See the full changelog for migration details.
+
+### Earlier — v1.4.1
 
 - **Multi-Provider AI Backend** - Mix and match AI providers for embeddings and chat: Ollama (local, default), OpenAI, Anthropic (Claude), claude CLI, and OpenAI-compatible servers (LM Studio, vLLM, LocalAI). Fallback chains and circuit breakers for resilience.
 - **Agent Attribution** - Track which agent and machine stored each memory with automatic detection

--- a/integrations/local-memory-skill/.claude-plugin/plugin.json
+++ b/integrations/local-memory-skill/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "local-memory",
+  "version": "1.0.0",
+  "description": "Persistent knowledge for AI agents: capture insights, recall prior context, and grow durable expertise across sessions with the Local Memory MCP server.",
+  "author": {
+    "name": "D.E. Williams & Co.",
+    "url": "https://localmemory.co"
+  },
+  "homepage": "https://localmemory.co",
+  "repository": "https://github.com/danieleugenewilliams/local-memory-releases",
+  "license": "SEE LICENSE IN README",
+  "keywords": ["local-memory", "mcp", "memory", "knowledge", "world-memory", "agent-skill"]
+}

--- a/integrations/local-memory-skill/.mcp.json
+++ b/integrations/local-memory-skill/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "local-memory": {
+      "type": "stdio",
+      "command": "local-memory",
+      "args": ["--mcp"]
+    }
+  }
+}

--- a/integrations/local-memory-skill/README.md
+++ b/integrations/local-memory-skill/README.md
@@ -1,0 +1,87 @@
+# Local Memory — Agent Skill
+
+A single [Agent Skill](https://agentskills.io) that teaches AI agents to use
+[Local Memory](https://localmemory.co) well: capture insights, recall prior context,
+and grow durable expertise across sessions — through whichever interface the agent has
+(MCP tools, the `local-memory` CLI, or the REST API).
+
+`SKILL.md` is an open standard read natively by Claude Code/Desktop, OpenAI Codex,
+Gemini CLI, Cursor, GitHub Copilot/VS Code, and Windsurf. Author once, run everywhere.
+
+## What's here
+
+```
+local-memory-skill/
+├── .claude-plugin/plugin.json     # Claude Code plugin manifest (bundles MCP + skill)
+├── .mcp.json                      # MCP server config (registers server as "local-memory")
+├── skills/local-memory/
+│   ├── SKILL.md                   # the skill: what/when, interface selection, core loop
+│   └── reference/
+│       ├── concepts.md            # World Memory model (levels, evolution, contradictions)
+│       ├── mcp.md                 # every MCP tool + current params
+│       ├── cli.md                 # CLI commands, flags, automation
+│       ├── rest.md                # REST endpoints + curl
+│       └── setup.md               # install, config, troubleshooting
+├── install.sh                     # copy the skill into a skills dir
+└── README.md
+```
+
+`skills/local-memory/` is the source of truth. The plugin wrapper and `install.sh` both
+point at that one copy.
+
+## Prerequisite
+
+The skill teaches *usage*; you still need Local Memory installed and running:
+
+```bash
+npm install -g local-memory-mcp
+local-memory setup
+local-memory license activate LM-XXXX-XXXX-XXXX-XXXX-XXXX --accept_terms
+local-memory start
+```
+
+See `skills/local-memory/reference/setup.md` for details.
+
+## Install the skill
+
+### Claude Code — as a plugin (also wires up the MCP server)
+
+Load this directory as a plugin so users get the skill **and** the MCP server in one step:
+
+```bash
+claude --plugin-dir ./local-memory-skill        # local test session
+claude plugin validate ./local-memory-skill     # check the manifests
+```
+
+The bundled `.mcp.json` registers the server as `local-memory` by invoking
+`local-memory --mcp` (expects the binary on `PATH`; edit the `command` to an absolute
+path otherwise). For persistent installs, distribute via a plugin marketplace.
+
+### Any other agent — copy the skill folder
+
+```bash
+./install.sh agents     # ~/.agents/skills (Gemini CLI, Cursor, Copilot, ...)
+./install.sh claude     # ~/.claude/skills (Claude Code/Desktop, no plugin)
+./install.sh codex      # ~/.codex/skills  (OpenAI Codex)
+./install.sh all        # all of the above
+./install.sh agents --project   # scope to ./.agents/skills in the current repo
+```
+
+Or copy `skills/local-memory/` by hand into the skills directory your agent scans.
+`~/.agents/skills` is the vendor-neutral path read by the widest set of agents.
+
+After installing, restart the agent (or run its reload command).
+
+> **Aider** has no skill auto-discovery — load `skills/local-memory/SKILL.md` manually
+> with `/read-only`.
+
+## Notes
+
+- **Server name.** Tool references assume the MCP server is registered as `local-memory`
+  (tools appear as `local-memory:<tool>`). If you register it under another name, adjust
+  the prefix and the `allowed-tools` list in `SKILL.md`.
+- **`allowed-tools`** in `SKILL.md` pre-approves Local Memory's read/capture tools for
+  Claude (other agents apply their own permission models); the destructive
+  `delete_memory` is intentionally excluded.
+- **Scope.** This skill replaces the *usage* prompts (the MCP/REST/CLI tabs) at
+  localmemory.co/prompts. The OS installation walkthroughs there are out of scope.

--- a/integrations/local-memory-skill/install.sh
+++ b/integrations/local-memory-skill/install.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+#
+# Install the Local Memory agent skill into a skills directory that your agent reads.
+#
+# Usage:
+#   ./install.sh [target] [--project]
+#
+# target (where to install):
+#   agents   Vendor-neutral ~/.agents/skills  (Gemini CLI, Cursor, Copilot, ...) [default]
+#   claude   ~/.claude/skills              (Claude Code / Claude Desktop)
+#   codex    ~/.codex/skills              (OpenAI Codex)
+#   all      Install into every directory above
+#
+# --project   Install into the current repo's ./.<target>/skills instead of $HOME,
+#             so the skill is scoped to (and can be committed with) this project.
+#
+# This copies skills/local-memory. It does NOT install the MCP server itself
+# (`npm install -g local-memory-mcp`) — see README.md.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SRC="$SCRIPT_DIR/skills/local-memory"
+
+TARGET="${1:-agents}"
+SCOPE_DIR="$HOME"
+for arg in "$@"; do
+  if [ "$arg" = "--project" ]; then SCOPE_DIR="$(pwd)"; fi
+done
+
+if [ ! -d "$SRC" ]; then
+  echo "error: skill source not found at $SRC" >&2
+  exit 1
+fi
+
+install_to() {
+  local base="$1"                      # e.g. .agents, .claude, .codex
+  local dest="$SCOPE_DIR/$base/skills/local-memory"
+  mkdir -p "$(dirname "$dest")"
+  rm -rf "$dest"
+  cp -R "$SRC" "$dest"
+  echo "installed -> $dest"
+}
+
+case "$TARGET" in
+  agents) install_to ".agents" ;;
+  claude) install_to ".claude" ;;
+  codex)  install_to ".codex"  ;;
+  all)    install_to ".agents"; install_to ".claude"; install_to ".codex" ;;
+  --project) install_to ".agents" ;;   # bare `--project` -> default target
+  *) echo "unknown target: $TARGET (use: agents | claude | codex | all)" >&2; exit 1 ;;
+esac
+
+echo "Done. Restart your agent (or run its reload command) to pick up the skill."

--- a/integrations/local-memory-skill/skills/local-memory/SKILL.md
+++ b/integrations/local-memory-skill/skills/local-memory/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: local-memory
+description: >-
+  Persistent knowledge system for AI agents. Use proactively to build expertise
+  across sessions: capture insights, decisions, bug fixes, and patterns; recall
+  what was learned before answering ("what do we already know about X", "have we
+  seen this before", "remember this"); detect contradictions and track open
+  questions. Works through Local Memory's MCP tools, CLI (`local-memory`), or
+  REST API (localhost:3002). Trigger whenever durable knowledge should be stored
+  or retrieved rather than re-derived.
+allowed-tools: >-
+  mcp__local-memory__bootstrap mcp__local-memory__search mcp__local-memory__ask
+  mcp__local-memory__summarize mcp__local-memory__observe mcp__local-memory__reflect
+  mcp__local-memory__evolve mcp__local-memory__question mcp__local-memory__questions
+  mcp__local-memory__resolve mcp__local-memory__relate mcp__local-memory__find_related
+  mcp__local-memory__discover mcp__local-memory__map_graph mcp__local-memory__status
+  mcp__local-memory__predict mcp__local-memory__explain mcp__local-memory__counterfactual
+  mcp__local-memory__temporal mcp__local-memory__get_memory_by_id
+  mcp__local-memory__update_memory mcp__local-memory__validate
+  mcp__local-memory__migrate_domain
+  Bash(local-memory:*)
+---
+
+# Local Memory
+
+Local Memory is a persistent, local-first knowledge layer. It is not a file store —
+it turns raw **observations** into **learnings**, then **patterns**, then
+**schemas**, so an agent accumulates durable expertise instead of re-deriving it
+every session.
+
+Use it proactively. Storing and recalling knowledge is cheap; re-discovering it is
+not.
+
+## Pick the interface (do this first)
+
+The same operations are available three ways. Use whichever the environment offers,
+in this order of preference:
+
+1. **MCP tools** — if tools named `local-memory:*` are available, use them. Lowest
+   overhead, structured results. (This skill pre-approves the read/capture tools.)
+2. **CLI** — if you can run shell commands, use the `local-memory` binary.
+3. **REST API** — if you can only make HTTP calls, use `http://localhost:3002/api/v1`.
+
+> Tool names below assume the MCP server is registered as **`local-memory`** (so a
+> tool is `local-memory:search`). If it was registered under another name, substitute
+> that prefix.
+
+Confirm the service is reachable before relying on it: call `local-memory:status`
+(MCP), run `local-memory status` (CLI), or `curl http://localhost:3002/api/v1/health`
+(REST). If unreachable, see [reference/setup.md](reference/setup.md).
+
+## The core loop
+
+```
+bootstrap  →  search/ask (before answering)  →  observe (as you learn)
+           →  reflect (synthesize)  →  evolve (validate & promote)
+```
+
+1. **Orient at session start.** Call `bootstrap` once to load relevant patterns,
+   recent learnings, and pending questions. It returns `memory_stats` and highlights —
+   read them before deciding what to do.
+2. **Recall before answering.** Before answering a non-trivial question or making a
+   decision, `search` for prior knowledge (or `ask` for a synthesized answer). Don't
+   re-derive what's already stored.
+3. **Capture as you learn.** When something worth keeping emerges, `observe` it.
+   Capture *why*, not just *what* — context, root cause, the decision and its
+   rationale. Tag consistently and set a `domain`.
+4. **Synthesize.** Periodically (or at session end) `reflect` to turn observations
+   (L0) into learnings (L1).
+5. **Mature knowledge.** When a learning proves correct, `evolve(operation="validate",
+   success=true)` to strengthen it; promotion to pattern/schema follows from repeated
+   validation.
+
+## What is worth storing
+
+- Architecture decisions and the rationale behind them
+- Bug fixes and their root causes (not just the symptom)
+- Approaches that worked — and ones that didn't, with why
+- User/project preferences, constraints, and conventions
+- Non-obvious facts that took effort to establish
+
+Skip ephemera that the repo, git history, or the current conversation already records.
+
+## Habits that make it work
+
+- **Specific beats vague.** "Postgres connection pool exhaustion under N+1 query in
+  the report job; fixed by eager-loading X" — not "fixed a DB bug."
+- **Tag and domain consistently** so retrieval works later.
+- **Search cross-session** (`session_filter_mode: "all"`) unless you deliberately want
+  only the current session.
+- **Track unknowns.** When you hit something you can't resolve, `question(...)` it.
+  When you later learn the answer, `resolve(...)` it.
+- **Surface contradictions** instead of silently overwriting. Let `resolve` / `evolve`
+  reconcile conflicting knowledge so history stays traceable. Prefer `evolve`/`update`
+  over `delete` — deletion loses the trail.
+
+## Knowledge levels (brief)
+
+| Level | Name | Weight | Meaning |
+|-------|------|--------|---------|
+| L0 | Observation | 0.0–1.0 | Raw intake, ephemeral |
+| L1 | Learning | 1.0–5.0 | Candidate insight |
+| L2 | Pattern | 5.0–9.0 | Validated generalization |
+| L3 | Schema | 9.0–10.0 | Durable framework |
+
+Full model — promotion thresholds, decay, contradictions, relationships — is in
+[reference/concepts.md](reference/concepts.md).
+
+## Reference (load as needed)
+
+- [reference/concepts.md](reference/concepts.md) — the World Memory model: levels,
+  evolution, contradictions, questions, relationship types, maintenance.
+- [reference/mcp.md](reference/mcp.md) — every MCP tool with current parameters and
+  examples.
+- [reference/cli.md](reference/cli.md) — `local-memory` commands and flags, plus
+  automation patterns (git hooks, cron).
+- [reference/rest.md](reference/rest.md) — REST endpoints, request shapes, and curl
+  examples.
+- [reference/setup.md](reference/setup.md) — install, configuration, service
+  management, and troubleshooting.
+
+## Token discipline
+
+Read operations accept a `response_format` (`detailed` / `concise` / `summary` /
+`ids_only`); `search` also has an `intelligent` format with a `max_tokens` budget.
+Default to `concise` and widen only when you need full content. See the reference
+files for per-tool specifics.

--- a/integrations/local-memory-skill/skills/local-memory/reference/cli.md
+++ b/integrations/local-memory-skill/skills/local-memory/reference/cli.md
@@ -1,0 +1,129 @@
+# CLI reference
+
+Use the `local-memory` binary when you can run shell commands but don't have the MCP
+tools. Same operations as MCP, exposed as subcommands. Most commands accept `--json`
+for machine-readable output; the read/retrieve commands (e.g. `search`, `get`,
+`analyze`) also accept `--response_format` to control verbosity. Many reasoning and
+lifecycle commands take their main inputs as **positional arguments**, not flags —
+check `local-memory <command> --help` for the exact signature.
+
+```bash
+local-memory --help                 # all commands
+local-memory <command> --help       # flags for one command
+local-memory search --help_parameters --show_all   # progressive parameter discovery
+```
+
+## Service management
+
+```bash
+local-memory start      # start daemon + REST API (port 3002)
+local-memory stop       # stop daemon
+local-memory status     # health, counts by level, domains, relationships, questions
+local-memory ps         # list running processes
+local-memory doctor     # comprehensive system + service check
+```
+
+## Capture
+
+```bash
+# Record an observation (L0 by default)
+local-memory observe "API returns 500s under load" --level observation --tags api,errors --domain backend
+
+# Store a learning directly
+local-memory observe "Circuit breaker prevents cascading failures" \
+  --level learning --weight 6.0 --tags architecture,resilience
+
+# Track a knowledge gap
+local-memory question "How does Redis handle persistence under high write load?" \
+  --question_type epistemic_gap --priority 7
+```
+
+`observe` flags: `--level` (observation|learning|pattern|schema), `--weight`,
+`--tags`, `--domain`, `--source`, `--context`, `--auto_promote`, `--session_id`.
+
+## Retrieve
+
+```bash
+local-memory search "concurrency patterns" --use_ai --limit 5
+local-memory search "python" --domain programming --tags web,scripting
+local-memory search "patterns" --start_date 2025-01-01 --end_date 2025-12-31
+local-memory get <memory-id>
+
+# AI analysis (Q&A / summarize / analyze / temporal)
+local-memory analyze "Differences between supervised and unsupervised learning?" --type question
+local-memory analyze --type summarize --timeframe month --limit 50
+local-memory analyze --type temporal_patterns --concept "deep learning" --temporal_timeframe quarter
+```
+
+Key `search` flags: `--use_ai`, `--limit`, `--tags`, `--domain`, `--search_type`
+(semantic|tags|date_range|hybrid), `--session_filter_mode` (all|session_only|
+session_and_shared), `--start_date`/`--end_date`, `--fields` (custom field selection),
+`--response_format` (detailed|concise|ids_only|summary|custom|intelligent|ultra|micro).
+
+## Synthesize & mature
+
+```bash
+# `reflect` takes the mode as a positional arg (single | batch | auto)
+local-memory reflect batch --batch_size 10
+local-memory reflect single --observation_id <uuid>
+
+# `evolve` takes the operation as a positional arg (validate | promote | decay | accommodate)
+local-memory evolve validate --entity_id <uuid> --success true
+local-memory evolve promote  --entity_id <uuid>
+local-memory evolve decay    --threshold_days 30 --dry_run
+
+# resolve takes question_id, resolution_type, and rationale as positional args
+local-memory resolve <question-id> a_supersedes "Newer info supersedes the older note"
+```
+
+## Graph & relationships
+
+```bash
+local-memory relate <source-id> <target-id> --type causes --strength 0.9 --confirm
+local-memory find_related <memory-id> --limit 10 --min_strength 0.5
+local-memory discover --limit 20 --min_strength 0.7
+local-memory map_graph <memory-id> --depth 3
+```
+
+> Note: the CLI `relate` default `--strength` is **0.8** (the MCP `relate` default is 0.5).
+
+## Reasoning
+
+```bash
+# predict/explain/counterfactual take their states as positional args
+local-memory predict "API receives high traffic" --use_ai
+local-memory explain "test passed locally" "deployment failed" --use_ai
+local-memory counterfactual "deployment failed" "we had run integration tests"
+```
+
+## Maintenance & admin
+
+```bash
+local-memory validate_graph --checks orphaned_reference,weight_inconsistency --dry_run
+local-memory update <memory-id> --content "Corrected content" --importance 9
+local-memory forget <memory-id> --confirm          # permanent delete — use sparingly
+local-memory migrate_domain --from old --to new --dry_run
+local-memory license activate LM-XXXX-XXXX-XXXX-XXXX-XXXX --accept_terms
+local-memory install mcp                            # configure MCP for detected clients
+```
+
+## Response formats
+
+`detailed` (full) · `concise` (~70% smaller) · `summary` (~50%) · `ids_only` (~95%) ·
+`custom` (with `--fields`) · `intelligent`/`ultra`/`micro` (progressively minimal).
+Available fields for `--fields`: `id, content, importance, tags, domain, created_at,
+updated_at, slug`.
+
+## Automation patterns
+
+```bash
+# Parse JSON output (--json emits the machine-readable envelope)
+local-memory search "api" --json | jq '.data.results[].memory.content'
+
+# Post-commit git hook (.git/hooks/post-commit)
+#!/bin/bash
+local-memory observe "Committed: $(git log -1 --oneline)" --level observation --tags git
+
+# Daily reflection via cron
+0 18 * * *  local-memory reflect batch
+```

--- a/integrations/local-memory-skill/skills/local-memory/reference/concepts.md
+++ b/integrations/local-memory-skill/skills/local-memory/reference/concepts.md
@@ -1,0 +1,153 @@
+# The World Memory model
+
+Local Memory is built on a four-level knowledge hierarchy. Knowledge enters as raw
+observation and is promoted toward durable understanding through validation. This
+file explains the model the tools operate on; for tool syntax see `mcp.md`, `cli.md`,
+or `rest.md`.
+
+## Knowledge levels
+
+| Level | Name | Weight range | Lifespan | Meaning |
+|-------|------|--------------|----------|---------|
+| L0 | Observation | 0.0–1.0 | Ephemeral | Raw intake meant to be processed, not kept as-is |
+| L1 | Learning | 1.0–5.0 | Volatile | A candidate insight synthesized from observations |
+| L2 | Pattern | 5.0–9.0 | Durable | A generalization validated across multiple learnings |
+| L3 | Schema | 9.0–10.0 | Permanent | A theoretical framework that explains patterns |
+
+`weight` is the confidence/durability score within a level. It rises on successful
+validation and falls on failed validation or decay.
+
+## The lifecycle
+
+```
+observe ──► reflect ──► evolve(validate) ──► evolve(promote) ──► relate
+  (L0)       (L0→L1)      (weight up)         (L1→L2→L3)        (link graph)
+                │
+                └─ question ──► resolve   (track and close knowledge gaps)
+```
+
+1. **observe** — record intake at L0 (or directly at a higher level when you already
+   know its standing). Capture context and source, not just the bare fact.
+2. **reflect** — synthesize one or many L0 observations into L1 learnings. This is
+   where raw notes become reusable insight.
+3. **evolve(validate)** — record that a learning held up (`success=true`) or failed
+   (`success=false`). Success raises weight; failure lowers it.
+4. **evolve(promote)** — advance a memory to the next level once it has earned it.
+   Promotion can also happen automatically when thresholds are met.
+5. **relate** — connect memories with typed edges so the graph encodes structure, not
+   just isolated facts.
+
+### Promotion thresholds (defaults)
+
+Promotion is gated on validation count, weight, and confidence (all configurable):
+
+- **L1 → L2 (Learning → Pattern):** ≥3 validations, weight ≥5.0, confidence ≥0.80
+- **L2 → L3 (Pattern → Schema):** ≥5 validations, weight ≥9.0, confidence ≥0.90
+
+Set `auto_promote: true` on `observe` to let a memory advance automatically once it
+clears the thresholds.
+
+## Decay and maintenance
+
+Knowledge that is never re-validated goes stale. `evolve(operation="decay")` reduces
+the weight of memories untouched for `threshold_days` (default 30); memories that
+fall below the archival threshold (~0.5) become candidates for archival. Always
+preview with `dry_run=true` before applying.
+
+Scheduled decay is **disabled by default** (`evolution.decay_enabled: false`). When
+enabled in daemon mode, it runs on an interval (default: every 24h, 30-day threshold).
+
+Run `validate` periodically to check graph integrity — orphaned references,
+relationship cycles, weight/level mismatches, stale questions, broken promotion
+chains, duplicate edges. It is read-only by default (`dry_run=true`); applying fixes
+requires both `dry_run=false` **and** `confirm_auto_fix=true`.
+
+## Contradiction detection
+
+When new knowledge conflicts with existing knowledge, Local Memory can detect it
+automatically. Detection layers (all must pass) include shared core vocabulary, same
+domain, negation asymmetry, opposing word pairs (always/never, increases/decreases),
+and the opposing terms applying to the same subject.
+
+Detected contradictions surface in `bootstrap` output and as `question`s of type
+`contradiction`. Resolve them with `resolve` rather than deleting one side — this
+keeps the reasoning trail intact.
+
+## Questions: tracking what you don't know
+
+Questions make epistemic gaps first-class:
+
+- `epistemic_gap` — something you know you don't know and should investigate
+- `contradiction` — a detected conflict between memories
+- `prediction_failure` — a prediction that turned out wrong (a learning signal)
+
+Record with `question`, list pending ones with `questions`, and close them with
+`resolve`. Resolution types:
+
+| Type | Use when |
+|------|----------|
+| `answered` | An epistemic gap now has an answer |
+| `a_supersedes` / `b_supersedes` | One memory is correct, the other outdated |
+| `conditional` | Both correct under different conditions |
+| `merged` | Synthesize a new memory from both (set `create_synthesis=true`) |
+| `context` | Different contexts; no real conflict |
+| `invalidated` | Both memories were wrong |
+
+## Relationship types
+
+`relate` connects two memories with a typed, weighted (0.0–1.0) edge:
+
+| Type | Meaning |
+|------|---------|
+| `references` | General reference (default) |
+| `contradicts` | Conflicting information |
+| `expands` | Elaborates on / builds upon |
+| `similar` | Related content |
+| `sequential` | Temporal or logical order |
+| `causes` | Causal link |
+| `enables` | Prerequisite / dependency |
+
+Two ways to find connections:
+
+- **`find_related`** — hybrid of explicit graph edges + vector similarity, seeded by a
+  memory ID. Returns related memories with level, connection strength, similarity.
+- **`map_graph`** — traverses *explicit* `relate` edges only (no similarity overlay),
+  returning nodes/edges/distances.
+- **`discover`** — surfaces *latent* relationship candidates across the base without
+  needing IDs; useful after a batch of observations.
+
+## Reasoning over knowledge
+
+Once patterns (L2) and schemas (L3) exist, three tools reason from them:
+
+- **`predict`** — given a context/action, predict likely outcomes from patterns/schemas.
+- **`explain`** — trace the causal path between two states through `causes`/`enables` edges.
+- **`counterfactual`** — "what if" reasoning over an alternative condition.
+
+Each accepts `use_ai=true` for richer, LLM-enhanced output (requires a local model;
+see `setup.md`).
+
+## Domains and sessions
+
+- **Domain** — a topical bucket (`programming`, `ai-research`, a project name). Set it
+  on `observe`; filter by it on `search`/`bootstrap`. Rename in bulk with
+  `migrate_domain` (preview with `dry_run` first).
+- **Session** — groups memories from one working context. `session_filter_mode`
+  controls retrieval scope: `all` (cross-session, the usual choice), `session_only`,
+  or `session_and_shared`. Auto-generated by default (commonly from git branch +
+  directory).
+
+## Token optimization
+
+Every read tool supports `response_format` to trade detail for tokens:
+
+| Format | Roughly | Use for |
+|--------|---------|---------|
+| `detailed` | 100% | When you need full content |
+| `summary` | ~50% | Truncated content, balanced |
+| `concise` | ~30% | Essential fields — a good default |
+| `ids_only` | ~5% | You only need IDs to fetch later |
+
+`search` additionally offers `format: "intelligent"` with a `max_tokens` budget that
+auto-optimizes the payload, and named `response_template`s (e.g. `agent_minimal`,
+`analysis_ready`) for common agent use cases.

--- a/integrations/local-memory-skill/skills/local-memory/reference/mcp.md
+++ b/integrations/local-memory-skill/skills/local-memory/reference/mcp.md
@@ -1,0 +1,273 @@
+# MCP tools reference
+
+The Local Memory MCP server exposes 24 tools. Parameters below match the current
+(v1.5.x) tool schemas. In prose, reference a tool as `local-memory:<name>` (assuming
+the server is registered as `local-memory`); when calling, use the host's tool-call
+format. Only `required` params must be supplied; everything else has the default shown.
+
+Quick map:
+
+| Group | Tools |
+|-------|-------|
+| Orient | `bootstrap`, `status` |
+| Capture | `observe`, `question` |
+| Retrieve | `search`, `ask`, `summarize`, `get_memory_by_id` |
+| Synthesize / mature | `reflect`, `evolve`, `resolve`, `questions` |
+| Graph | `relate`, `find_related`, `discover`, `map_graph` |
+| Reason | `predict`, `explain`, `counterfactual` |
+| Maintain | `validate`, `update_memory`, `delete_memory`, `migrate_domain`, `temporal` |
+
+---
+
+## Orient
+
+### bootstrap
+Initialize a session with relevant context. Returns `memory_stats` (counts by level,
+domain, relationships, questions, recent activity) and highlights. Call once at the start.
+- `mode` — `full` (default) | `minimal` | `domain`
+- `domain` — required when `mode="domain"`
+- `include_questions` / `include_learnings` / `include_patterns` — bool, default true
+- `limit` — items per category (default 20, max 100)
+- `session_id`
+
+```
+bootstrap(mode="full", include_questions=true)
+bootstrap(mode="domain", domain="programming")
+```
+
+### status
+Knowledge-base health and composition: totals, level distribution, open questions,
+recent activity. Use to confirm the service is up and to orient.
+- `response_format` — `detailed` (default) | `concise` | `summary`
+
+---
+
+## Capture
+
+### observe
+Record intake. L0 by default; pass `level` to store higher. Capture context/source,
+not just the fact.
+- `content` *(required)*
+- `level` — `observation` (default) | `learning` | `pattern` | `schema`
+- `tags` — string[]
+- `domain`, `source`, `context`
+- `weight` — 0.0–10.0 initial weight
+- `auto_promote` — bool, default false
+- `session_id`
+
+```
+observe(content="Redis SCAN is O(1) per call but O(N) overall",
+        tags=["redis","performance"], domain="databases")
+observe(content="Circuit breaker prevents cascading failures",
+        level="learning", weight=3.5, auto_promote=true)
+```
+
+### question
+Record a knowledge gap or conflict (this *records*; use `questions` to *list*).
+- `content` *(required)*
+- `question_type` — `epistemic_gap` (default) | `contradiction` | `prediction_failure`
+- `priority` — 1–10, default 5
+- `domain`, `origin_context`, `session_id`
+- `response_format` — `detailed` | `concise` (default) | `ids_only`
+
+---
+
+## Retrieve
+
+### search
+Semantic / tag / date / hybrid search. Use this when you have a query string and want
+ranked memories (use `ask` when you want a synthesized answer).
+- `query` — required for `semantic`/`hybrid`
+- `tags` — required for `tags`/`hybrid`
+- `search_type` — `semantic` (default) | `tags` | `date_range` | `hybrid`
+- `use_ai` — bool, default false; enables vector embeddings (more accurate, slower)
+- `domain`, `start_date`, `end_date` (YYYY-MM-DD)
+- `session_filter_mode` — `all` (default) | `session_only` | `session_and_shared`
+- `limit` — default 5, max 100
+- `format` — `intelligent` (default) | `detailed` | `summary` | `ids_only` (token-budgeted)
+- `max_tokens` — budget for `intelligent` (default 1000, 50–8000)
+- `response_format` — `detailed` | `concise` (default) | `ids_only` | `summary` | `custom`
+- `response_template` — e.g. `agent_minimal`, `analysis_ready`, `relationship_focused`
+- `cursor` / `page_size` — pagination
+
+```
+search(query="machine learning deployment", domain="ai", format="intelligent", max_tokens=500)
+search(tags=["python"], search_type="tags", page_size=20)
+```
+
+### ask
+Natural-language Q&A grounded in stored memories (synthesized answer + sources).
+- `question` *(required)*
+- `context_limit` — memories used as context (default 5, max 50)
+- `session_id`, `session_filter_mode` — `session_only` | `session_and_shared`
+- `response_format` — `detailed` (default) | `concise` | `ids_only`
+
+### summarize
+Summarize memories over a timeframe.
+- `timeframe` — `day` | `week` | `month` | `all` (default)
+- `limit` — default 20, max 100
+- `session_id`
+- `response_format` — `detailed` (default) | `concise` | `summary`
+
+### get_memory_by_id
+Direct lookup by ID; returns full content, level, weight, tags, metadata.
+- `id` *(required)*
+
+---
+
+## Synthesize & mature
+
+### reflect
+Process observations (L0) into learnings (L1).
+- `mode` — `single` | `batch` | `auto` (default `single`)
+- `observation_id` — required for `single` (UUID)
+- `batch_size` — default 10, max 50 (for `batch`)
+- `auto_criteria` — e.g. `time_based` (for `auto`)
+- `dry_run` — preview promotions without writing/invoking the model (default false)
+- `session_id`
+
+```
+reflect(mode="batch", batch_size=10)
+reflect(mode="single", observation_id="<uuid>")
+```
+
+### evolve
+Lifecycle operations on a memory.
+- `operation` *(required)* — `validate` | `promote` | `decay` | `accommodate`
+- `entity_id` — required for `validate`/`promote` (UUID)
+- `success` — required for `validate` (bool)
+- `context` — rationale
+- `threshold_days` — for `decay` (default 30, max 365)
+- `dry_run` — preview (recommended for `decay`)
+- `session_id`
+
+```
+evolve(operation="validate", entity_id="<uuid>", success=true, context="held up in prod")
+evolve(operation="decay", threshold_days=30, dry_run=true)
+```
+
+### resolve
+Close a question or reconcile a contradiction.
+- `question_id` *(required, UUID)*
+- `resolution_type` *(required)* — `answered` | `a_supersedes` | `b_supersedes` |
+  `conditional` | `merged` | `context` | `invalidated`
+- `rationale` *(required)*
+- `synthesis_content` + `create_synthesis` — for `merged`, optionally mint a new memory
+- `update_weights` (default true), `update_relationship` (default true)
+- `response_format` — `detailed` (default) | `concise` | `ids_only`
+
+### questions
+List existing questions/contradictions/gaps (to record one, use `question`).
+- `status` — `pending` (default) | `investigating` | `resolved` | `archived`
+- `question_type` — filter; `priority_min`; `domain`; `session_id`
+- `limit` (default 50, max 200), `offset`
+- `response_format` — `detailed` (default) | `concise` | `summary` | `ids_only`
+
+---
+
+## Graph
+
+### relate
+Create a typed edge between two memories.
+- `source_memory_id`, `target_memory_id` *(required, UUIDs)*
+- `relationship_type` — `references` (default) | `contradicts` | `expands` | `similar` |
+  `sequential` | `causes` | `enables`
+- `strength` — 0.0–1.0, **default 0.5** (note: the CLI `relate` default is 0.8)
+- `context`, `session_id`
+
+### find_related
+Related memories for a seed ID, via graph edges + vector similarity.
+- `memory_id` *(required)*
+- `limit` (default 10, max 100)
+- `min_similarity` — 0.0–1.0, default 0.0 (returns all)
+- `response_format` — `detailed` (default) | `concise` | `ids_only`
+
+### discover
+Latent relationship candidates across the base — no ID needed.
+- `limit` (default 10, max 100)
+- `min_strength` — default 0.5
+- `memory_id` — optional scope; `session_id` — optional scope
+- `relationship_type_filter` — string[]
+- `response_format` — `detailed` (default) | `concise` | `ids_only`
+
+### map_graph
+Traverse explicit `relate` edges around a memory; returns nodes/edges/distances.
+- `memory_id` *(required)*
+- `depth` — hops, default 2, max 5
+- `response_format` — `concise` (default) | `detailed` | `ids_only`
+
+---
+
+## Reason
+
+### predict
+Predict outcomes from patterns/schemas.
+- `given` *(required)*; `action` (optional)
+- `domain`; `schema_ids` (string[]); `use_ai` (default false); `limit` (default 5, max 20)
+- `response_format` — `detailed` (default) | `concise` | `summary` | `ids_only`
+
+### explain
+Trace the causal path between two states.
+- `from_state`, `to_state` *(required)*
+- `max_depth` — hops, default 4, max 10; `domain`; `use_ai`
+- `response_format` — `detailed` (default) | `concise` | `summary` | `ids_only`
+
+### counterfactual
+"What if" reasoning over an alternative condition.
+- `observed`, `if_condition` *(required)*
+- `domain`; `schema_ids`; `use_ai`
+- `response_format` — `detailed` (default) | `concise` | `summary` | `ids_only`
+
+---
+
+## Maintain
+
+### validate
+Knowledge-graph integrity check (read-only by default).
+- `checks` — subset of `orphaned_reference`, `relationship_cycle`,
+  `weight_inconsistency`, `stale_question`, `promotion_chain_broken`,
+  `duplicate_relationship` (empty = all)
+- `auto_fix` — default false
+- `dry_run` — default **true**
+- `confirm_auto_fix` — **required** to actually apply fixes (with `auto_fix=true,
+  dry_run=false`)
+- `domain`, `batch_size` (default 1000), `session_id`
+- `response_format` — `detailed` (default) | `concise` | `ids_only` | `summary`
+
+```
+validate()                                              # preview all
+validate(auto_fix=true, dry_run=false, confirm_auto_fix=true)   # apply
+```
+
+### update_memory
+Correct existing knowledge (content/importance/tags/domain). Prefer `evolve(promote)`
+when the knowledge has *advanced*; use `update_memory` for *corrections*.
+- `id` *(required)*; `content`, `importance` (1–10), `tags`, `domain`
+
+### delete_memory
+Permanently remove a memory. Use only for genuinely erroneous entries — if knowledge is
+merely superseded, prefer `resolve`/`evolve(accommodate)` to keep traceability.
+- `id` *(required)*  *(Not pre-approved by this skill — destructive.)*
+
+### migrate_domain
+Bulk-rename memories from one domain to another (case-insensitive match).
+- `from_domain`, `to_domain` *(required)*
+- `dry_run` — default **true** (preview first); `session_id` — optional scope
+
+### temporal
+Analyze how knowledge evolves over time.
+- `operation` *(required)* — `patterns` | `progression` | `gaps` | `timeline`
+- `concept` — required for `progression`; optional for `patterns`/`timeline`
+- `timeframe` — `week` | `month` (default) | `quarter` | `year` (for `patterns`)
+- `analysis_type` — `learning_progression` (default) | `knowledge_gaps` | `concept_evolution`
+- `focus_areas` (for `gaps`); `start_date`/`end_date`/`memory_ids` (for `timeline`)
+- `response_format` — `detailed` | `concise` (default) | `summary`
+
+---
+
+## Deprecated tools
+
+Hidden but still functional for backward compatibility (avoid in new work; slated for
+removal in v2.0): `store_memory` → use `observe`; `analysis` → `predict`/`explain`/
+`counterfactual`; `stats` → `status`; `relationships` → `relate`; `sessions` →
+`bootstrap`; `domains` → `domain` param; `categories` → `tags` param.

--- a/integrations/local-memory-skill/skills/local-memory/reference/rest.md
+++ b/integrations/local-memory-skill/skills/local-memory/reference/rest.md
@@ -1,0 +1,125 @@
+# REST API reference
+
+Use the REST API when you can only make HTTP calls. Base URL:
+`http://localhost:3002/api/v1` (port auto-selects 3002–3005 if 3002 is busy). No auth
+for local use. Ensure the daemon is running first:
+
+```bash
+local-memory start
+curl http://localhost:3002/api/v1/health      # -> {"data":{"status":"healthy"},...}
+```
+
+## Response patterns (important)
+
+Two shapes, by endpoint category:
+
+- **CRUD / admin** (memories, search, categories, domains, system) wrap results:
+  `{ "success": true, "message": "...", "data": { ... } }`
+- **Knowledge-engineering** (`observe`, `question`, `evolve`, `reflect`, `predict`,
+  `explain`, `counterfactual`, `resolve`, `validate`, `bootstrap`, `relate`,
+  `temporal/*`) return **raw JSON** (operation-specific fields; most include
+  `"success": true`, but some — e.g. `POST /bootstrap` — omit it).
+
+For knowledge-engineering endpoints, trust the **HTTP status code** (2xx = success;
+`POST /observe` returns 201 on create, others 200).
+Errors: `{"error":"error","code":400,"message":"..."}` or `{"error":"not_found","id":"..."}`.
+
+Field notes (verified against a live v1.5.0 daemon):
+- `POST /observe` returns the new id in **`memory_id`** (top level), plus `level`,
+  `level_label`, `suggested_actions`, and `summary` — not a `data` envelope.
+- `GET /memories/search` returns `{ "count": N, "data": [...] }` (no `message`).
+- `DELETE /memories/{id}` returns the full envelope and 404s on an unknown id.
+- `GET /questions` works for listing even though it is omitted from the `GET /api/v1/`
+  catalog.
+
+## Core memory
+
+```bash
+# Store (creates an L0 observation by default; pass "level" to go higher)
+curl -X POST http://localhost:3002/api/v1/memories \
+  -H "Content-Type: application/json" \
+  -d '{"content":"Your insight","importance":8,"tags":["t1","t2"],"domain":"backend"}'
+
+# Search (always set response_format explicitly)
+curl "http://localhost:3002/api/v1/memories/search?query=neural%20networks&use_ai=true&response_format=detailed"
+
+# Advanced search with cursor pagination
+curl -X POST http://localhost:3002/api/v1/memories/search \
+  -H "Content-Type: application/json" \
+  -d '{"query":"machine learning","limit":20,"response_format":"concise","cursor":"<opaque>"}'
+
+# Get / update / delete by id
+curl http://localhost:3002/api/v1/memories/<id>
+curl -X PUT http://localhost:3002/api/v1/memories/<id> -H "Content-Type: application/json" -d '{"importance":9}'
+curl -X DELETE http://localhost:3002/api/v1/memories/<id>
+```
+
+## Knowledge engineering
+
+```bash
+# Orient
+curl -X POST http://localhost:3002/api/v1/bootstrap -H "Content-Type: application/json" \
+  -d '{"mode":"full","include_questions":true}'
+curl http://localhost:3002/api/v1/status
+
+# Capture
+curl -X POST http://localhost:3002/api/v1/observe -H "Content-Type: application/json" \
+  -d '{"content":"API rate limits are 100/min","level":"learning","tags":["api","limits"]}'
+curl -X POST http://localhost:3002/api/v1/question -H "Content-Type: application/json" \
+  -d '{"content":"How does X persist under load?","question_type":"epistemic_gap","priority":7}'
+
+# Synthesize & mature
+curl -X POST http://localhost:3002/api/v1/reflect -H "Content-Type: application/json" -d '{"mode":"batch","batch_size":10}'
+curl -X POST http://localhost:3002/api/v1/evolve  -H "Content-Type: application/json" \
+  -d '{"operation":"validate","entity_id":"<uuid>","success":true}'
+curl -X POST http://localhost:3002/api/v1/resolve -H "Content-Type: application/json" \
+  -d '{"question_id":"<uuid>","resolution_type":"answered","rationale":"..."}'
+curl "http://localhost:3002/api/v1/questions?status=pending"
+
+# Reason
+curl -X POST http://localhost:3002/api/v1/predict        -d '{"given":"high traffic","use_ai":true}' -H "Content-Type: application/json"
+curl -X POST http://localhost:3002/api/v1/explain        -d '{"from_state":"login","to_state":"purchase"}' -H "Content-Type: application/json"
+curl -X POST http://localhost:3002/api/v1/counterfactual -d '{"observed":"deploy failed","if_condition":"ran tests"}' -H "Content-Type: application/json"
+```
+
+## Analysis, relationships, temporal
+
+```bash
+# AI Q&A / summarize / analyze (smart-routes by analysis_type)
+curl -X POST http://localhost:3002/api/v1/ask       -d '{"question":"What is Redis?","use_ai":true}' -H "Content-Type: application/json"
+curl -X POST http://localhost:3002/api/v1/summarize -d '{"timeframe":"month","limit":20}'           -H "Content-Type: application/json"
+
+# Relationships
+curl -X POST http://localhost:3002/api/v1/relationships -H "Content-Type: application/json" \
+  -d '{"source_memory_id":"<id1>","target_memory_id":"<id2>","relationship_type":"causes","strength":0.9}'
+curl -X POST http://localhost:3002/api/v1/relationships/discover -d '{"min_strength":0.6,"limit":10}' -H "Content-Type: application/json"
+curl "http://localhost:3002/api/v1/memories/<id>/related?limit=10"
+curl "http://localhost:3002/api/v1/memories/<id>/graph?depth=2"
+
+# Temporal
+curl -X POST http://localhost:3002/api/v1/temporal/patterns -H "Content-Type: application/json" \
+  -d '{"analysis_type":"learning_progression","concept":"machine learning","timeframe":"month"}'
+curl -X POST http://localhost:3002/api/v1/temporal/gaps -d '{"focus_areas":["deep learning"]}' -H "Content-Type: application/json"
+```
+
+## Token optimization
+
+Add `response_format` to any read: `detailed` | `concise` (~70% smaller) | `summary`
+(~50%) | `ids_only` (~95%) | `custom`. Response templates also exist (`agent_minimal`,
+`analysis_ready`, `relationship_focused`, `temporal_analysis`, `metadata_only`,
+`full_context`).
+
+```bash
+curl -X POST http://localhost:3002/api/v1/memories/search \
+  -H "Content-Type: application/json" \
+  -d '{"query":"machine learning","response_format":"ids_only"}'
+```
+
+## Endpoint groups (overview)
+
+Core memory (CRUD + search) · AI analysis (`/ask`, `/summarize`, `/analyze`) ·
+relationships (`/relationships`, `/relationships/discover`, `/memories/{id}/related`,
+`/memories/{id}/graph`) · temporal (`/temporal/{patterns,progression,gaps,timeline}`) ·
+knowledge engineering (`/observe`, `/question`, `/bootstrap`, `/evolve`, `/reflect`,
+`/predict`, `/explain`, `/counterfactual`, `/resolve`, `/questions`, `/validate`,
+`/relate`, `/status`) · system (`/health`, `/stats`, `/config`). Full list: `GET /api/v1/`.

--- a/integrations/local-memory-skill/skills/local-memory/reference/setup.md
+++ b/integrations/local-memory-skill/skills/local-memory/reference/setup.md
@@ -1,0 +1,100 @@
+# Setup, configuration & troubleshooting
+
+What an agent needs to get Local Memory running, point itself at the right service, and
+recover when something is wrong. (Full OS-by-OS install walkthroughs with license keys
+live on localmemory.co; this is the operational subset.)
+
+## Is it running?
+
+Always confirm reachability before relying on the store:
+
+```bash
+local-memory status                         # CLI
+curl http://localhost:3002/api/v1/health    # REST -> {"data":{"status":"healthy"},...}
+```
+
+Via MCP, call `local-memory:status`. If the MCP tools aren't present at all, the server
+isn't registered with this client — fall back to CLI or REST, or see "MCP not
+connecting" below.
+
+## Install / start
+
+```bash
+npm install -g local-memory-mcp     # install
+local-memory setup                  # first-run wizard (or --silent / --interactive)
+local-memory license activate LM-XXXX-XXXX-XXXX-XXXX-XXXX --accept_terms   # required for commercial use
+local-memory start                  # start daemon + REST API
+local-memory doctor                 # verify everything
+local-memory install mcp            # configure MCP for detected clients (claude-desktop, cursor, ...)
+```
+
+Manual install: download the binary from the releases page, put it on `PATH`, then
+`local-memory setup`.
+
+## Optional AI services
+
+Some operations are AI-enhanced (`ask`, semantic `search` with `use_ai`, and
+`predict`/`explain`/`counterfactual` with `use_ai=true`). These use a local model stack:
+
+- **Ollama** (default `http://localhost:11434`) — embeddings `nomic-embed-text`,
+  chat `qwen2.5:3b`. Auto-detected.
+- **Qdrant** (default `http://localhost:6333`) — optional vector DB for faster/larger
+  semantic search. Disabled by default; SQLite vector search works without it.
+
+Core capture/retrieve works without these; AI features degrade gracefully if absent.
+
+## Configuration
+
+Config + data live in `~/.local-memory/` (Windows: `%USERPROFILE%\.local-memory\`). The
+config loader creates it `0700` (owner-only); the `setup` wizard's location check creates
+it `0755`. Because `mkdir -p` never re-modes an existing directory, the actual mode is set
+by whichever runs first — often `0755` in practice. Key files: `config.yaml` (main
+config), `unified-memories.db` (SQLite store), `daemon.log`, `qdrant-storage/`.
+
+Precedence (highest first): `--config <path>` → `./local-memory/config.yaml` →
+`./.local-memory/config.yaml` → `~/.local-memory/config.yaml`. YAML or JSON; any setting
+can be overridden by a `MEMORY_`-prefixed env var.
+
+Settings worth knowing:
+
+```yaml
+rest_api:   { enabled: true, auto_port: true, port: 3002, host: localhost }
+ollama:     { enabled: true, auto_detect: true, embedding_model: nomic-embed-text, chat_model: "qwen2.5:3b" }
+qdrant:     { enabled: false, url: "http://localhost:6333", vector_size: 768 }
+mcp:        { enable_legacy_tools: false }   # set true only to re-expose deprecated tools
+session:    { auto_generate: true, strategy: git-directory }
+evolution:  { decay_enabled: false, decay_interval_hours: 24, decay_threshold_days: 30 }  # scheduled decay off by default
+contradiction: { enabled: true, similarity_threshold: 0.85 }
+```
+
+Common env overrides:
+
+```bash
+export LOCAL_MEMORY_CONFIG_DIR="$HOME/.local-memory"
+export MEMORY_REST_API_PORT="3002"
+export MEMORY_OLLAMA_BASE_URL="http://localhost:11434"
+export MEMORY_LICENSE_KEY="LM-XXXX-XXXX-XXXX-XXXX"
+```
+
+**Config changes require a daemon restart** (`local-memory stop && local-memory start`).
+Core settings (DB path, license, service URLs) always need a full restart.
+
+## Troubleshooting
+
+| Symptom | Action |
+|---------|--------|
+| MCP tools absent | `local-memory install mcp`, then restart the MCP client. Until then use CLI/REST. |
+| Service unreachable | `local-memory ps`; if down, `local-memory start`; then `local-memory doctor`. |
+| Port 3002 in use | Daemon auto-selects 3002–3005; check `local-memory status` for the actual port. |
+| AI features failing | `local-memory doctor` to check Ollama/Qdrant; AI is optional. |
+| License rejected | Watch for em/en-dashes (—/–) pasted instead of hyphens (-); re-activate. |
+| Permission errors | `chmod 700 ~/.local-memory`. |
+| Stuck processes | `local-memory kill_all`, then `local-memory start`. |
+| Inspect logs | `tail -f ~/.local-memory/daemon.log`. |
+
+## MCP server name
+
+This skill assumes the MCP server is registered as **`local-memory`**, so tools appear
+as `local-memory:<tool>` / `mcp__local-memory__<tool>`. If it was registered under a
+different name (e.g. `local-memory-latest`), the tool prefix and the `allowed-tools` in
+`SKILL.md` change accordingly. The bundled `.mcp.json` registers it as `local-memory`.


### PR DESCRIPTION
## What

Brings the public distribution repo up to date with the shipped **v1.5.1** release and publishes the cross-vendor **agent skill** here so end users can actually reach it.

### README
- **Version 1.4.1 → 1.5.1.** Refreshed "What's New": v1.5.1 (`questions` listing tool), v1.5.0 (Knowledge Engineering Maturity + the 1.4.x breaking changes), with the old v1.4.1 notes preserved under "Earlier".
- **Fixed a broken Quick Start command.** `remember` was **removed in v1.5.0** (LMG-007) — the README still told users to run `./local-memory remember`, which now errors `unknown command "remember"`. Changed to `observe`. Also added `--accept_terms` to the license-activation example (canonical non-interactive flow).
- **Fixed the download table.** Removed the **macOS (Universal)** row — `local-memory-universal.zip` is **not** an asset in the v1.5.1 release, so the `/releases/latest/download/...` link 404s. Added the **Linux (ARM64)** binary, which ships in the release but was missing from the table. The table now matches the release's actual 5 platform assets.

### Publish the agent skill
- Mirrored `integrations/local-memory-skill/` from the (private) source repo into this **public** repo. The skill's own `plugin.json` already declares `"repository": "…/local-memory-releases"`, and the plugin / `install.sh` / marketplace flows need a public source — so this is where it belongs. Files are byte-identical to the source (`diff -rq` clean); `install.sh` stays executable and `plugin.json` validates.

## Notes
- Verified all command/flag changes against the v1.5.1 binary (`remember` removed, `--accept_terms` valid, release asset list).
- No binary or code changes — docs + skill files only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)